### PR TITLE
fix: make text unwrapping opt-in

### DIFF
--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -64,6 +64,9 @@ licenses:
   #
   #   Important Note: this means the ident must be a valid SPDX identifier
   #   auto_template: true
+  # 
+  #   Try to detect the text wrapping of the template, and unwrap it
+  #   unwrap_text: false
 
 # Define type of comment characters to apply based on file extensions.
 comments:

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -68,6 +68,8 @@ pub struct Config {
 
     template: Option<String>,
     auto_template: Option<bool>,
+
+    unwrap_text: bool,
 }
 
 impl Config {
@@ -138,6 +140,7 @@ impl Config {
                 ident: self.ident.clone(),
                 year: self.year.clone(),
                 authors: self.authors.clone(),
+                unwrap_text: self.unwrap_text,
             },
         );
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -53,6 +53,7 @@ pub struct Context {
     pub ident: String,
     pub authors: Authors,
     pub year: Option<String>,
+    pub unwrap_text: bool,
 }
 
 impl Context {
@@ -119,11 +120,13 @@ impl Template {
 
         let mut templ = self.content.clone();
 
-        // Some license headers come pre-textwrapped. This regex
-        // replacement removes their wrapping while preserving
-        // intentional newlines.
-        let re = Regex::new("[A-z0-9]\n").unwrap();
-        templ = re.replace_all(&templ, " ").to_string();
+        if self.context.unwrap_text {
+            // Some license headers come pre-textwrapped. This regex
+            // replacement removes their wrapping while preserving
+            // intentional newlines.
+            let re = Regex::new("[A-z0-9]\n").unwrap();
+            templ = re.replace_all(&templ, " ").to_string();
+        }
 
         // Perform our substitutions
         templ

--- a/src/template.rs
+++ b/src/template.rs
@@ -117,8 +117,16 @@ impl Template {
             ("[year]", "[name of author]", "[ident]")
         };
 
+        let mut templ = self.content.clone();
+
+        // Some license headers come pre-textwrapped. This regex
+        // replacement removes their wrapping while preserving
+        // intentional newlines.
+        let re = Regex::new("[A-z0-9]\n").unwrap();
+        templ = re.replace_all(&templ, " ").to_string();
+
         // Perform our substitutions
-        self.content
+        templ
             .replace(year_repl, &self.context.get_year())
             .replace(author_repl, &self.context.get_authors())
             .replace(ident_repl, &self.context.ident)

--- a/src/template.rs
+++ b/src/template.rs
@@ -117,16 +117,8 @@ impl Template {
             ("[year]", "[name of author]", "[ident]")
         };
 
-        let mut templ = self.content.clone();
-
-        // Some license headers come pre-textwrapped. This regex
-        // replacement removes their wrapping while preserving
-        // intentional newlines.
-        let re = Regex::new("[A-z0-9]\n").unwrap();
-        templ = re.replace_all(&templ, " ").to_string();
-
         // Perform our substitutions
-        templ
+        self.content
             .replace(year_repl, &self.context.get_year())
             .replace(author_repl, &self.context.get_authors())
             .replace(ident_repl, &self.context.ident)


### PR DESCRIPTION
Prior to this, all \n should have come with trailing whitespace before them, which causes the editor to remove them. This removal fixes this issue. There is no need to change the wrapping of the template

Fixes #9 