### PR TITLE
Auto update license year

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{md,adoc}]
+indent_size = 4
+
+[*.rs]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 /target
 **/*.rs.bk
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 description = "A software license management tool"
 repository = "https://github.com/chasinglogic/licensure"
 homepage = "https://github.com/chasinglogic/licensure"
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "chasinglogic/licensure", branch = "master" }

--- a/src/comments/block_comment.rs
+++ b/src/comments/block_comment.rs
@@ -1,5 +1,6 @@
-use super::Comment;
 use crate::comments::line_comment::LineComment;
+
+use super::Comment;
 
 pub struct BlockComment {
     start: String,

--- a/src/comments/mod.rs
+++ b/src/comments/mod.rs
@@ -13,11 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-mod block_comment;
-mod line_comment;
-
 pub use block_comment::BlockComment;
 pub use line_comment::LineComment;
+
+mod block_comment;
+mod line_comment;
 
 pub trait Comment {
     fn comment(&self, text: &str, columns: Option<usize>) -> String;

--- a/src/config/comment.rs
+++ b/src/config/comment.rs
@@ -114,5 +114,4 @@ pub mod tests {
     fn test_get_filetype() {
         assert_eq!("py", get_filetype("test.py"))
     }
-
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,17 +7,17 @@ use std::process;
 use regex::RegexSet;
 use serde::Deserialize;
 
-mod comment;
-mod default;
-mod license;
-
 pub use default::DEFAULT_CONFIG;
 
 use crate::comments::Comment;
-use crate::config::comment::get_filetype;
 use crate::config::comment::Config as CommentConfig;
+use crate::config::comment::get_filetype;
 use crate::config::license::Config as LicenseConfig;
 use crate::template::Template;
+
+mod comment;
+mod default;
+mod license;
 
 fn def_change_in_place() -> bool {
     false

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::io::prelude::*;
 
 use crate::config::Config;
+use crate::utils::trim_trailing_whitespace;
 
 pub struct Licensure {
     config: Config,
@@ -13,8 +14,9 @@ impl Licensure {
         Licensure { config }
     }
 
-    pub fn license_files(self, files: &[String]) -> Result<Vec<&String>, io::Error> {
-        let mut files_not_licensed = Vec::new();
+    pub fn license_files(self, files: &[String]) -> Result<LicenseStats, io::Error> {
+        let mut stats = LicenseStats::new();
+
         for file in files {
             if self.config.excludes.is_match(file) {
                 continue;
@@ -28,35 +30,72 @@ impl Licensure {
                 }
             };
 
-            let uncommented = templ.render();
             let (cfg, commenter) = self.config.comments.get_commenter(file);
+
+            let uncommented = templ.render();
             let mut header = commenter.comment(&uncommented, cfg.get_columns());
+
             let mut content = String::new();
             {
                 let mut f = File::open(file)?;
                 f.read_to_string(&mut content)?;
             }
 
-            // TODO: make this smarter about updating years etc.
             if content.contains(&header) {
                 info!("{} already licensed", file);
                 continue;
             }
-            files_not_licensed.push(file);
+
+            let outdated_re = templ.outdated_license_pattern(&commenter, cfg.get_columns());
+            if outdated_re.is_match(&content) {
+                info!("{} licensed, but year is outdated", file);
+                stats.files_needing_license_update.push(file.clone());
+
+                let updated = outdated_re.replace(&content, header);
+
+                if self.config.change_in_place {
+                    let mut f = File::create(file)?;
+                    f.write_all(updated.as_bytes())?;
+                } else {
+                    println!("{}", updated);
+                }
+
+                continue;
+            } else {
+                let trimmed_outdated_re = templ.outdated_license_trimmed_pattern(&commenter, cfg.get_columns());
+                if trimmed_outdated_re.is_match(&content) {
+                    info!("{} licensed, but year is outdated", file);
+                    stats.files_needing_license_update.push(file.clone());
+
+                    let updated = trimmed_outdated_re.replace(&content, header);
+
+                    if self.config.change_in_place {
+                        let mut f = File::create(file)?;
+                        f.write_all(updated.as_bytes())?;
+                    } else {
+                        println!("{}", updated);
+                    }
+
+                    continue;
+                }
+            }
+
+            stats.files_not_licensed.push(file.clone());
 
             // if already licensed but the trailing lines/whitespace do not match
-            let content_trimmed = content.trim_end_matches(|c| c == '\n' || c == '\r' || c == ' ');
-            let header_trimmed = header.trim_end_matches(|c| c == '\n' || c == '\r' || c == ' ');
+            let content_trimmed = trim_trailing_whitespace(&content);
+            let header_trimmed = trim_trailing_whitespace(&header);
+
             if content_trimmed.contains(header_trimmed) {
                 info!(
                     "{} already licensed but the trailing lines/whitespace do not match",
                     file
                 );
-                // ignore the trailing lines for now so it does not result in duplicate license headers
-                continue; // TODO fix the trailing whitespace or empty lines to match the template
-            }
 
-            header.push_str(&content);
+                header = content.replace(header_trimmed, &header);
+            } else {
+                header.push_str(&content);
+            }
 
             if self.config.change_in_place {
                 let mut f = File::create(file)?;
@@ -66,6 +105,17 @@ impl Licensure {
             }
         }
 
-        Ok(files_not_licensed)
+        Ok(stats)
+    }
+}
+
+pub struct LicenseStats {
+    pub files_not_licensed: Vec<String>,
+    pub files_needing_license_update: Vec<String>,
+}
+
+impl LicenseStats {
+    fn new() -> Self {
+        Self { files_not_licensed: Vec::new(), files_needing_license_update: Vec::new() }
     }
 }

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::io::prelude::*;
 
 use crate::config::Config;
-use crate::utils::trim_trailing_whitespace;
 
 pub struct Licensure {
     config: Config,
@@ -83,8 +82,8 @@ impl Licensure {
             stats.files_not_licensed.push(file.clone());
 
             // if already licensed but the trailing lines/whitespace do not match
-            let content_trimmed = trim_trailing_whitespace(&content);
-            let header_trimmed = trim_trailing_whitespace(&header);
+            let content_trimmed = content.trim_end();
+            let header_trimmed = header.trim_end();
 
             if content_trimmed.contains(header_trimmed) {
                 info!(

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -60,23 +60,23 @@ impl Licensure {
                 }
 
                 continue;
-            } else {
-                let trimmed_outdated_re = templ.outdated_license_trimmed_pattern(&commenter, cfg.get_columns());
-                if trimmed_outdated_re.is_match(&content) {
-                    info!("{} licensed, but year is outdated", file);
-                    stats.files_needing_license_update.push(file.clone());
+            }
 
-                    let updated = trimmed_outdated_re.replace(&content, header);
+            let trimmed_outdated_re = templ.outdated_license_trimmed_pattern(&commenter, cfg.get_columns());
+            if trimmed_outdated_re.is_match(&content) {
+                info!("{} licensed, but year is outdated", file);
+                stats.files_needing_license_update.push(file.clone());
 
-                    if self.config.change_in_place {
-                        let mut f = File::create(file)?;
-                        f.write_all(updated.as_bytes())?;
-                    } else {
-                        println!("{}", updated);
-                    }
+                let updated = trimmed_outdated_re.replace(&content, header);
 
-                    continue;
+                if self.config.change_in_place {
+                    let mut f = File::create(file)?;
+                    f.write_all(updated.as_bytes())?;
+                } else {
+                    println!("{}", updated);
                 }
+
+                continue;
             }
 
             stats.files_not_licensed.push(file.clone());

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -45,7 +45,7 @@ impl Licensure {
                 continue;
             }
 
-            let outdated_re = templ.outdated_license_pattern(&commenter, cfg.get_columns());
+            let outdated_re = templ.outdated_license_pattern(commenter.as_ref(), cfg.get_columns());
             if outdated_re.is_match(&content) {
                 info!("{} licensed, but year is outdated", file);
                 stats.files_needing_license_update.push(file.clone());
@@ -62,7 +62,7 @@ impl Licensure {
                 continue;
             }
 
-            let trimmed_outdated_re = templ.outdated_license_trimmed_pattern(&commenter, cfg.get_columns());
+            let trimmed_outdated_re = templ.outdated_license_trimmed_pattern(commenter.as_ref(), cfg.get_columns());
             if trimmed_outdated_re.is_match(&content) {
                 info!("{} licensed, but year is outdated", file);
                 stats.files_needing_license_update.push(file.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
 
 More information is available at: {}",
                 ABOUT,
-                AUTHORS.replace(":", ", "),
+                AUTHORS.replace(':', ", "),
                 HOMEPAGE
             )
                 .as_str(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod comments;
 mod config;
 mod licensure;
 mod template;
+mod utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod comments;
 mod config;
 mod licensure;
 mod template;
+mod utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
@@ -186,12 +187,22 @@ More information is available at: {}",
             println!("Failed to license files: {}", e);
             process::exit(1);
         }
-        Ok(files_not_licensed) => {
-            if matches.is_present("check") && !files_not_licensed.is_empty() {
-                eprintln!("The following files were not licensed with the given config.");
-                for file in files_not_licensed {
-                    eprintln!("{}", file);
+        Ok(stats) => {
+            if matches.is_present("check") && !(stats.files_not_licensed.is_empty() && stats.files_needing_license_update.is_empty()) {
+                if !stats.files_needing_license_update.is_empty() {
+                    eprintln!("The following files' licenses need to be updated");
+                    for file in stats.files_needing_license_update {
+                        eprintln!("{}", file);
+                    }
                 }
+
+                if !stats.files_not_licensed.is_empty() {
+                    eprintln!("The following files were not licensed with the given config.");
+                    for file in stats.files_not_licensed {
+                        eprintln!("{}", file);
+                    }
+                }
+
                 process::exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,6 @@ mod comments;
 mod config;
 mod licensure;
 mod template;
-mod utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,22 +23,22 @@ extern crate serde;
 extern crate serde_yaml;
 extern crate textwrap;
 
+use std::fs::File;
+use std::io::ErrorKind;
+use std::io::prelude::*;
+use std::process;
+use std::process::Command;
+
+use chrono::offset::{Offset, Utc};
+use clap::{App, Arg};
+
+use config::DEFAULT_CONFIG;
+use licensure::Licensure;
+
 mod comments;
 mod config;
 mod licensure;
 mod template;
-
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::ErrorKind;
-use std::process;
-use std::process::Command;
-
-use clap::{App, Arg};
-use chrono::offset::{Offset, Utc};
-
-use config::DEFAULT_CONFIG;
-use licensure::Licensure;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
@@ -77,7 +77,7 @@ More information is available at: {}",
                 AUTHORS.replace(":", ", "),
                 HOMEPAGE
             )
-            .as_str(),
+                .as_str(),
         )
         .arg(
             Arg::with_name("verbose")
@@ -130,7 +130,7 @@ More information is available at: {}",
                 .set_time_offset(Utc.fix())
                 .build(),
         )
-        .unwrap(),
+            .unwrap(),
     };
 
     if matches.is_present("generate-config") {

--- a/src/template.rs
+++ b/src/template.rs
@@ -164,7 +164,7 @@ impl Template {
             // joining the fragments with the year-matching regex pattern
             // effectively inserts itself into all the locations where the
             // intermediate token existed. We now have a regex that matches
-            // the exact license header text, except with any 4-digit year.
+            // the exact license header text, but with any 4-digit year.
             //
             // And we only care about 4-digit years in our lifetime ;).
             .join(YEAR_RE);

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,8 @@
+use std::fmt;
+
 use chrono::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
-use std::fmt;
 
 #[derive(Clone, Deserialize)]
 struct CopyrightHolder {

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,7 +5,6 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::comments::Comment;
-use crate::utils::trim_trailing_whitespace;
 
 #[derive(Clone, Deserialize)]
 struct CopyrightHolder {
@@ -132,7 +131,7 @@ impl Template {
         );
 
         if trim_trailing {
-            rendered = trim_trailing_whitespace(&rendered).to_string()
+            rendered = rendered.trim_end().to_string();
         }
 
         let escaped: Vec<_> = rendered

--- a/src/template.rs
+++ b/src/template.rs
@@ -4,6 +4,9 @@ use chrono::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
 
+use crate::comments::Comment;
+use crate::utils::trim_trailing_whitespace;
+
 #[derive(Clone, Deserialize)]
 struct CopyrightHolder {
     name: String,
@@ -77,6 +80,14 @@ pub struct Template {
     context: Context,
 }
 
+// this token needs to be exactly 4 chars; this is temporarily used when formatting
+// the template into a comment regex with the correct column width that can match
+// the [year] against /[\d]{4}/
+const INTERMEDIATE_YEAR_TOKEN: &'static str = "@YR@";
+
+// Matches any full 4-digit year
+const YEAR_RE: &'static str = "[0-9]{4}";
+
 impl Template {
     pub fn new(template: &str, context: Context) -> Template {
         Template {
@@ -91,8 +102,59 @@ impl Template {
         self
     }
 
-    pub fn render(self) -> String {
-        let (year_repl, author_repl, ident_repl) = if self.spdx_template {
+    pub fn outdated_license_pattern(&self, commenter: &Box<dyn Comment>, columns: Option<usize>) -> Regex {
+        self.build_year_varying_regex(&mut self.content.clone(), commenter, columns, false)
+    }
+
+    pub fn outdated_license_trimmed_pattern(&self, commenter: &Box<dyn Comment>, columns: Option<usize>) -> Regex {
+        self.build_year_varying_regex(&mut self.content.clone(), commenter, columns, true)
+    }
+
+    pub fn render(&self) -> String {
+        let (year_repl, author_repl, ident_repl) = self.replacement_tokens();
+        let template = self.unwrap_license_headers(&mut self.content.clone());
+
+        // Perform our substitutions
+        template
+            .replace(year_repl, &self.context.get_year())
+            .replace(author_repl, &self.context.get_authors())
+            .replace(ident_repl, &self.context.ident)
+    }
+
+    fn build_year_varying_regex(&self, content: &mut str, commenter: &Box<dyn Comment>, columns: Option<usize>, trim_trailing: bool) -> Regex {
+        let (year_repl, author_repl, ident_repl) = self.replacement_tokens();
+        let mut rendered = commenter.comment(
+            &(self.unwrap_license_headers(content)
+                .replace(year_repl, INTERMEDIATE_YEAR_TOKEN)
+                .replace(author_repl, &self.context.get_authors())
+                .replace(ident_repl, &self.context.ident)),
+            columns,
+        );
+
+        if trim_trailing {
+            rendered = trim_trailing_whitespace(&rendered).to_string()
+        }
+
+        let escaped: Vec<_> = rendered
+            .split(INTERMEDIATE_YEAR_TOKEN)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|frag| { regex::escape(frag) })
+            .collect::<Vec<_>>();
+
+        Regex::new(&(escaped.join(YEAR_RE))).unwrap()
+    }
+
+    fn unwrap_license_headers(&self, template: &mut str) -> String {
+        // Some license headers come pre-textwrapped. This regex
+        // replacement removes their wrapping while preserving
+        // intentional line breaks / empty lines.
+        let re = Regex::new(r"(?P<char>.)\n").unwrap();
+        re.replace_all(&template, "$char ").to_string()
+    }
+
+    fn replacement_tokens(&self) -> (&'static str, &'static str, &'static str) {
+        if self.spdx_template {
             // Check if it's the Apache license which has a super
             // special format.
             if self.content.contains("[name of copyright owner]") {
@@ -112,26 +174,14 @@ impl Template {
             }
         } else {
             ("[year]", "[name of author]", "[ident]")
-        };
-
-        let mut templ = self.content.clone();
-
-        // Some license headers come pre-textwrapped. This regex
-        // replacement removes their wrapping while preserving
-        // intentional line breaks / empty lines.
-        let re = Regex::new(r"(?P<char>.)\n").unwrap();
-        templ = re.replace_all(&templ, "$char ").to_string();
-
-        // Perform our substitutions
-        templ
-            .replace(year_repl, &self.context.get_year())
-            .replace(author_repl, &self.context.get_authors())
-            .replace(ident_repl, &self.context.ident)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::comments::LineComment;
+
     use super::*;
 
     #[test]
@@ -159,6 +209,42 @@ mod tests {
         let template = Template::new("Copyright (C) [year] [name of author] This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>", context);
         let expected = String::from("Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>");
         assert_eq!(expected, template.render())
+    }
+
+    #[test]
+    fn test_outdated_license_matching() {
+        let context = Context {
+            ident: String::from("test"),
+            authors: Authors::from(vec![CopyrightHolder {
+                name: "Mathew Robinson".to_string(),
+                email: Some("chasinglogic@gmail.com".to_string()),
+            }]),
+            year: Some(String::from("2022")),
+        };
+        let template = Template::new("Copyright (C) [year] [name of author] This program is free software.", context);
+        let commenter: Box<dyn Comment> = Box::new(LineComment::new("#"));
+        let re = template.outdated_license_pattern(&commenter, Option::Some(1000));
+        assert_eq!(true, re.is_match("# Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software.\n"))
+    }
+
+    #[test]
+    fn test_outdated_license_trimmed_matching() {
+        let context = Context {
+            ident: String::from("test"),
+            authors: Authors::from(vec![CopyrightHolder {
+                name: "Mathew Robinson".to_string(),
+                email: Some("chasinglogic@gmail.com".to_string()),
+            }]),
+            year: Some(String::from("2022")),
+        };
+        let template = Template::new("Copyright (C) [year] [name of author] This program is free software.", context);
+        let commenter: Box<dyn Comment> = Box::new(LineComment::new("#").set_trailing_lines(2));
+        let re = template.outdated_license_pattern(&commenter, Option::Some(1000));
+        assert_eq!(true, re.is_match("# Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software.\n\n\n"));
+        assert_eq!(false, re.is_match("# Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software."));
+
+        let trimmed = template.outdated_license_trimmed_pattern(&commenter, Option::Some(1000));
+        assert_eq!(true, trimmed.is_match("# Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software."))
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub fn trim_trailing_whitespace(string: &str) -> &str {
+    string.trim_end_matches(|c| c == '\n' || c == '\r' || c == ' ')
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,9 +6,8 @@ pub fn remove_column_wrapping(string: &str) -> String {
     // while preserving intentional line breaks / empty lines.
     let re = Regex::new(r"(?P<char>.)\n").unwrap();
     re
-        .replace_all(&string, "$char ")
+        .replace_all(string, "$char ")
         .replace(" \n", "\n\n")
-        .to_string()
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,34 @@
+use regex::Regex;
+
+pub fn remove_column_wrapping(string: &str) -> String {
+    // Some license headers come pre-wrapped to a column width.
+    // This regex replacement undoes the column-width wrapping
+    // while preserving intentional line breaks / empty lines.
+    let re = Regex::new(r"(?P<char>.)\n").unwrap();
+    re
+        .replace_all(&string, "$char ")
+        .replace(" \n", "\n\n")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::remove_column_wrapping;
+
+    #[test]
+    fn test_remove_column_wrapping() {
+        let content = "\
+some wrapped
+text to unwrap.
+
+The line above
+is an intentional
+line break.
+
+So is this.";
+
+        let expected = "some wrapped text to unwrap.\n\nThe line above \
+        is an intentional line break.\n\nSo is this.";
+        assert_eq!(expected, remove_column_wrapping(&content))
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,0 @@
-pub fn trim_trailing_whitespace(string: &str) -> &str {
-    string.trim_end_matches(|c| c == '\n' || c == '\r' || c == ' ')
-}


### PR DESCRIPTION
@chasinglogic this change should update the copyright headers with the current year.

As I mentioned in my [last comment](https://github.com/chasinglogic/licensure/issues/3#issuecomment-1323440509), I did not implement the `--year` flag, largely because I wasn't clear as to its behavior when multiple licenses are configured. I think if this still needs to be implemented, it could be a separate effort/PR. WDYT?

Please have a look! Note that I am quite new to rust, so let me know if I'm not doing something idiomatic or if I could express something better.

I've tested this out on my project, and it seems to work fine. Hope it works on yours as well.