### PR TITLE
Add support for shebang

### DIFF
--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -64,10 +64,8 @@ impl Licensure {
             let shebang_end = {
                 let shebang_match_opt = shebang_re.find(&content);
                 match shebang_match_opt {
-                    Some(shebang_match) => {
-                        Option::Some(shebang_match.end())
-                    }
-                    None => Option::None
+                    Some(shebang_match) => Option::Some(shebang_match.end()),
+                    None => Option::None,
                 }
             };
             // If we idenfied a shebang, strip it from content (we'll add it back at the end)
@@ -76,8 +74,8 @@ impl Licensure {
                     let mut shebang = content;
                     content = shebang.split_off(split_at);
                     Some(shebang)
-                },
-                None => { Option::None }
+                }
+                None => Option::None,
             };
 
             if content.contains(&header) {
@@ -142,7 +140,7 @@ impl Licensure {
                 Some(val) => {
                     header.insert_str(0, &val);
                 }
-                None => {},
+                None => {}
             }
 
             if self.config.change_in_place {

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::process::exit;
 use std::{clone, io};
 use std::io::prelude::*;
 

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -59,7 +59,7 @@ impl Licensure {
                 }
             }
 
-            let shebang_re: Regex = Regex::new(r"^#!.*\n").unwrap();
+            let shebang_re: Regex = Regex::new(r"^#!.*\n").expect("shebang regex didn't compile!");
             let full_content: String = content.clone();
             let shebang_match_opt = shebang_re.find(&full_content);
             let shebang_opt = match shebang_match_opt {

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -77,7 +77,7 @@ impl Licensure {
                     content = shebang.split_off(split_at);
                     Some(shebang)
                 },
-                _ => { Option::None }
+                None => { Option::None }
             };
 
             if content.contains(&header) {


### PR DESCRIPTION
I noticed the tool doesn't support the case where the file has a shebang, e.g.

```
#!/usr/bin/bash
# ... a leading comment ...
echo "example"
```
 would become:

```
# <license header>
#!/usr/bin/bash
# ... a leading comment ...
echo "example"
```

With this change, the shebang is maintained in the right spot:

```
#!/usr/bin/bash
# <license header>
# ... a leading comment ...
echo "example"
```


.. I wasn't sure of the cleanest way to do this, so I made it so that the shebang is effectively removed while you do your "can I just update this" checks, and is only re-added at the end. I suspect that's probably least likely to break your existing logic.

If you've got feedback, I'll try to address it.