### PR TITLE
feat: Allow disabling the default commenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,19 +197,6 @@ is provided via the command line.
 change_in_place: true
 ```
 
-#### default_commenter
-
-Takes a boolean indicating whether a default commenter should be assumed if no
-other commenter matches a given file. This defaults to `true` but can be set to
-`false` to instead not comment in cases where no appropriate commenter can be
-found.
-
-**Example Configuration:**
-
-```yaml
-default_commenter: false
-```
-
 #### exclude
 
 Takes a list of strings that will be compiled as regexes to filter out

--- a/README.md
+++ b/README.md
@@ -197,6 +197,19 @@ is provided via the command line.
 change_in_place: true
 ```
 
+#### default_commenter
+
+Takes a boolean indicating whether a default commenter should be assumed if no
+other commenter matches a given file. This defaults to `true` but can be set to
+`false` to instead not comment in cases where no appropriate commenter can be
+found.
+
+**Example Configuration:**
+
+```yaml
+default_commenter: false
+```
+
 #### exclude
 
 Takes a list of strings that will be compiled as regexes to filter out

--- a/src/config/comment.rs
+++ b/src/config/comment.rs
@@ -74,18 +74,6 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn default() -> Config {
-        Config {
-            extension: FileType::Single("any".to_string()),
-            files: None,
-            columns: None,
-            commenter: Commenter::Line {
-                comment_char: "#".to_string(),
-                trailing_lines: 0,
-            },
-        }
-    }
-
     pub fn matches(&self, file_type: &str, filename: &str) -> bool {
         if self.extension.matches(file_type) {
             if let Some(files) = &self.files {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,16 +36,11 @@ mod license;
 fn default_off() -> bool {
     false
 }
-fn default_on() -> bool {
-    true
-}
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
     #[serde(default = "default_off")]
     pub change_in_place: bool,
-    #[serde(default = "default_on")]
-    pub default_commenter: bool,
 
     pub excludes: RegexList,
     pub licenses: LicenseConfigList,
@@ -126,10 +121,6 @@ impl CommentConfigList {
             }
         }
         None
-    }
-
-    pub fn get_default_commenter(&self) -> Box<dyn Comment> {
-        CommentConfig::default().commenter()
     }
 }
 

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -168,11 +168,7 @@ impl Licensure {
         let commenter = match self.config.comments.get_commenter(file) {
             Some(c) => c,
             None => {
-                if self.config.default_commenter {
-                    self.config.comments.get_default_commenter()
-                } else {
-                    return LicenseStatus::NoCommenterMatched;
-                }
+                return LicenseStatus::NoCommenterMatched;
             }
         };
 
@@ -453,7 +449,6 @@ licenses:
     authors:
       - name: The Tester
     template: "New Test License [name of author]\nOnly For Testing"
-default_commenter: false
 comments: []
 "##;
 
@@ -469,37 +464,5 @@ comments: []
         .to_string();
         let result = l.add_license_header(&"test_file.c".to_string(), &mut content);
         assert_eq!(result, LicenseStatus::NoCommenterMatched);
-    }
-
-    static CONFIG_DEFAULT_COMMENTER_TRUE: &str = r##"
-excludes: []
-licenses:
-  - files: any
-    ident: TESTING
-    authors:
-      - name: The Tester
-    template: "New Test License [name of author]"
-comments: []
-"##;
-    #[test]
-    fn test_add_license_header_default_commenter_true() {
-        let config: Config = serde_yaml::from_str(CONFIG_DEFAULT_COMMENTER_TRUE)
-            .expect("Static config to be parsable");
-        let mut l = Licensure::new(config);
-        let mut content = r#"
-some content
-"#
-        .to_string();
-        let result = l.add_license_header(&"test_file.txt".to_string(), &mut content);
-        assert_eq!(
-            result,
-            LicenseStatus::NeedsUpdate(
-                r#"# New Test License The Tester
-
-some content
-"#
-                .to_string()
-            )
-        );
     }
 }

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -31,6 +31,7 @@ enum LicenseStatus {
     NeedsUpdate(String),
     AlreadyLicensed,
     NoConfigMatched,
+    NoCommenterMatched,
 }
 
 impl Licensure {
@@ -67,6 +68,10 @@ impl Licensure {
             match self.add_license_header(file, &mut content) {
                 LicenseStatus::NeedsUpdate(update) => self.handle_update(file, &update)?,
                 LicenseStatus::NoConfigMatched => self.stats.files_not_licensed.push(file.clone()),
+                LicenseStatus::NoCommenterMatched => {
+                    self.stats.files_not_licensed.push(file.clone());
+                    self.stats.files_needing_commenter.push(file.clone())
+                }
                 LicenseStatus::AlreadyLicensed => continue,
             }
         }
@@ -160,7 +165,16 @@ impl Licensure {
             }
         };
 
-        let commenter = self.config.comments.get_commenter(file);
+        let commenter = match self.config.comments.get_commenter(file) {
+            Some(c) => c,
+            None => {
+                if self.config.default_commenter {
+                    self.config.comments.get_default_commenter()
+                } else {
+                    return LicenseStatus::NoCommenterMatched;
+                }
+            }
+        };
 
         let uncommented = templ.render();
         let header = commenter.comment(&uncommented);
@@ -193,6 +207,7 @@ impl Licensure {
 pub struct LicenseStats {
     pub files_not_licensed: Vec<String>,
     pub files_needing_license_update: Vec<String>,
+    pub files_needing_commenter: Vec<String>,
 }
 
 impl LicenseStats {
@@ -200,6 +215,7 @@ impl LicenseStats {
         Self {
             files_not_licensed: Vec::new(),
             files_needing_license_update: Vec::new(),
+            files_needing_commenter: Vec::new(),
         }
     }
 }
@@ -427,5 +443,63 @@ if __name__ == '__main__':
                 .to_string()
             )
         )
+    }
+
+    static CONFIG_DEFAULT_COMMENTER_FALSE: &str = r##"
+excludes: []
+licenses:
+  - files: any
+    ident: TESTING
+    authors:
+      - name: The Tester
+    template: "New Test License [name of author]\nOnly For Testing"
+default_commenter: false
+comments: []
+"##;
+
+    #[test]
+    fn test_add_license_header_default_commenter_false() {
+        let config: Config = serde_yaml::from_str(CONFIG_DEFAULT_COMMENTER_FALSE)
+            .expect("Static config to be parsable");
+        let mut l = Licensure::new(config);
+        let mut content = r#"
+// Before replacement
+# include somefile.h
+"#
+        .to_string();
+        let result = l.add_license_header(&"test_file.c".to_string(), &mut content);
+        assert_eq!(result, LicenseStatus::NoCommenterMatched);
+    }
+
+    static CONFIG_DEFAULT_COMMENTER_TRUE: &str = r##"
+excludes: []
+licenses:
+  - files: any
+    ident: TESTING
+    authors:
+      - name: The Tester
+    template: "New Test License [name of author]"
+comments: []
+"##;
+    #[test]
+    fn test_add_license_header_default_commenter_true() {
+        let config: Config = serde_yaml::from_str(CONFIG_DEFAULT_COMMENTER_TRUE)
+            .expect("Static config to be parsable");
+        let mut l = Licensure::new(config);
+        let mut content = r#"
+some content
+"#
+        .to_string();
+        let result = l.add_license_header(&"test_file.txt".to_string(), &mut content);
+        assert_eq!(
+            result,
+            LicenseStatus::NeedsUpdate(
+                r#"# New Test License The Tester
+
+some content
+"#
+                .to_string()
+            )
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,16 @@ More information is available at: {}",
                     }
                 }
 
+                if !stats.files_needing_commenter.is_empty() {
+                    eprintln!(
+                        "The following {} files did not have a commenter with the given config.",
+                        stats.files_needing_commenter.len()
+                    );
+                    for file in stats.files_needing_commenter {
+                        eprintln!("{}", file);
+                    }
+                }
+
                 process::exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,39 +216,46 @@ More information is available at: {}",
                 && !(stats.files_not_licensed.is_empty()
                     && stats.files_needing_license_update.is_empty())
             {
-                if !stats.files_needing_license_update.is_empty() {
-                    eprintln!(
-                        "The following {} files' licenses need to be updated",
-                        stats.files_needing_license_update.len()
-                    );
-                    for file in stats.files_needing_license_update {
-                        eprintln!("{}", file);
-                    }
-                }
+                print_files(
+                    &stats.files_needing_license_update,
+                    "files' licenses need to be updated",
+                );
 
-                if !stats.files_not_licensed.is_empty() {
-                    eprintln!(
-                        "The following {} files were not licensed with the given config.",
-                        stats.files_not_licensed.len()
-                    );
-                    for file in stats.files_not_licensed {
-                        eprintln!("{}", file);
-                    }
-                }
+                print_files(
+                    &stats.files_not_licensed,
+                    "files were not licensed with the given config.",
+                );
 
-                if !stats.files_needing_commenter.is_empty() {
-                    eprintln!(
-                        "The following {} files did not have a commenter with the given config.",
-                        stats.files_needing_commenter.len()
-                    );
-                    for file in stats.files_needing_commenter {
-                        eprintln!("{}", file);
-                    }
-                }
+                print_files(
+                    &stats.files_needing_commenter,
+                    "files did not have a commenter with the given config.",
+                );
 
                 process::exit(1);
             }
+
+            if print_files(
+                &stats.files_needing_commenter,
+                "files did not have a commenter with the given config.",
+            ) {
+                process::exit(1);
+            };
         }
+    }
+}
+
+/// Print the given list of files (if non-empty) with a message "The following X
+/// Y" where X is the number of files to be printed and Y is the given message
+/// parameter. Returns true if files were printed and false otherwise.
+fn print_files(files: &Vec<String>, message: &str) -> bool {
+    if !files.is_empty() {
+        eprintln!("The following {} {} ", message, files.len());
+        for file in files {
+            eprintln!("{}", file);
+        }
+        true
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
The fact that there's a default commenter for all files that don't match a more specific commenter was very surprising to me. This PR adds a global config option to disable to default commenter and instead report those files which do not match a configured commenter.