### PR TITLE
Exit with non-zero return code if not all files were licensed.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,10 @@ More information is available at: {}",
 
                 process::exit(1);
             }
+
+            if !stats.files_not_licensed.is_empty() {
+                process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
If attempting to add a license to all files and licensure is unable to do so, it's very helpful (especially for in CI jobs) if a non-zero return code can be returned. This PR adds a non-zero return when failing to license all files.