### PR TITLE
feat: Respect start and end year when use_automated_year_ranges is on

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,33 @@ If you want per-file year ranges or just automated ones you can opt in with the
 to determine a files created and last updated year. It will then license that
 file with a year range specific to it based on the `git` information.
 
+Note that this will respect the `start_year` and `end_year` settings and simply
+populate whichever you do not set accordingly to the year alone. For example if
+you have this config:
+
+```yaml
+licenses:
+  - files: any
+    use_dynamic_year_ranges: true
+    # Note the leading space because start year and end year will just be
+    # formatted one after the other.
+    end_year: " and all future years"
+    authors:
+      - name: Mathew Robinson
+        email: chasinglogic@gmail.com
+        ident: MIT
+    template: |
+      Copyright [year] [name of author]. All rights reserved. Use of
+      this source code is governed by the [ident] license that can be
+      found in the LICENSE file.
+```
+
+And a file with a created year of 2019 you'll get a copyright line like this:
+
+```
+Copyright (c) 2019 and all future years ...
+```
+
 #### comments
 
 The comments section is a list of comment configuration

--- a/scripts/local_install.sh
+++ b/scripts/local_install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -x
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+REPO=$(git rev-parse --show-toplevel)
+
+cd "$REPO" || exit 1
+
+cargo build --release
+
+if [[ -x $(which strip) ]]; then
+    strip ./target/release/licensure
+fi
+
+mv ./target/release/licensure "$INSTALL_DIR/"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,8 +24,8 @@ use serde::Deserialize;
 pub use default::DEFAULT_CONFIG;
 
 use crate::comments::Comment;
-use crate::config::comment::get_filetype;
 use crate::config::comment::Config as CommentConfig;
+use crate::config::comment::get_filetype;
 use crate::config::license::Config as LicenseConfig;
 use crate::template::Template;
 

--- a/src/licensure.rs
+++ b/src/licensure.rs
@@ -257,7 +257,7 @@ mod test {
     use crate::template::test_context_with_range;
     use crate::{
         comments::LineComment,
-        template::{test_context, Template},
+        template::{Template, test_context},
     };
 
     #[test]
@@ -324,9 +324,11 @@ mod test {
         let result = l.get_replaces_replacement(&replaces, content, &header);
         eprintln!("{:?}", result);
         assert!(result.is_some());
-        assert!(result
-            .unwrap()
-            .eq("BEFORE// License 2024\n//\n// text\nAFTER"));
+        assert!(
+            result
+                .unwrap()
+                .eq("BEFORE// License 2024\n//\n// text\nAFTER")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ extern crate textwrap;
 extern crate ureq;
 
 use std::fs::File;
-use std::io::prelude::*;
 use std::io::ErrorKind;
+use std::io::prelude::*;
 use std::path::Path;
 use std::process;
 use std::process::Command;
@@ -179,9 +179,13 @@ More information is available at: {}",
     } else {
         matches
             .values_of("FILES")
-            .expect("ERROR: Must provide files to license either as matches or via --project")
-            .map(str::to_string)
-            .collect()
+            .map(|files| files.map(str::to_string).collect())
+            .unwrap_or_else(|| {
+                eprintln!(
+                    "ERROR: Must provide files to license either as matches or via --project"
+                );
+                process::exit(10);
+            })
     };
 
     let mut config = match config::load_config() {

--- a/src/template.rs
+++ b/src/template.rs
@@ -87,7 +87,7 @@ impl Context {
         };
 
         match &self.start_year {
-            Some(start_year) if *start_year != end_year => format!("{}, {}", start_year, end_year),
+            Some(start_year) => format!("{}{}", start_year, end_year),
             _ => end_year,
         }
     }
@@ -306,8 +306,13 @@ mod tests {
             start_year: None,
             unwrap_text: true,
         };
-        let template = Template::new("Copyright (C) [year] [name of author] This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>", context);
-        let expected = String::from("Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>");
+        let template = Template::new(
+            "Copyright (C) [year] [name of author] This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>",
+            context,
+        );
+        let expected = String::from(
+            "Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>",
+        );
         assert_eq!(expected, template.render())
     }
 
@@ -382,7 +387,9 @@ have received a copy of the GNU Affero General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>",
             context,
         );
-        let expected = String::from("Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>");
+        let expected = String::from(
+            "Copyright (C) 2020 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>",
+        );
         assert_eq!(expected, template.render())
     }
 
@@ -450,12 +457,17 @@ Free Software Foundation, version 3. This program is distributed in the hope tha
                 name: "Mathew Robinson".to_string(),
                 email: Some("chasinglogic@gmail.com".to_string()),
             }]),
-            end_year: Some(String::from("2024")),
+            end_year: Some(String::from(", 2024")),
             start_year: Some(String::from("2020")),
             unwrap_text: true,
         };
-        let template = Template::new("Copyright (C) [year] [name of author] This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>", context);
-        let expected = String::from("Copyright (C) 2020, 2024 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>");
+        let template = Template::new(
+            "Copyright (C) [year] [name of author] This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>",
+            context,
+        );
+        let expected = String::from(
+            "Copyright (C) 2020, 2024 Mathew Robinson <chasinglogic@gmail.com> This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>",
+        );
         assert_eq!(expected, template.render())
     }
 }


### PR DESCRIPTION
This enables use cases where you want all copyright to have some set start year or end year. It also allows custom messages such as `2020 and all future years` by setting `end_year: " and all future years"`.