### PR TITLE
feat: Add support for git year listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,37 @@ And a file with a created year of 2019 you'll get a copyright line like this:
 Copyright (c) 2019 and all future years ...
 ```
 
+###### Automated year lists
+
+If you want the copyright to enumerate every individual year the file was
+modified (rather than just a start–end range) you can use the
+`use_git_year_list: true` setting. This will use `git` commit information to
+collect all years in which the file was committed and list them in ascending
+order, deduplicated.
+
+```yaml
+licenses:
+  - files: any
+    use_git_year_list: true
+    authors:
+      - name: Mathew Robinson
+        email: chasinglogic@gmail.com
+    ident: MIT
+    template: |
+      Copyright [year] [name of author]. All rights reserved. Use of
+      this source code is governed by the [ident] license that can be
+      found in the LICENSE file.
+```
+
+For a file committed in 2019, 2021, and 2024 you'll get a copyright line like:
+
+```
+Copyright 2019, 2021, 2024 ...
+```
+
+Note that `use_git_year_list` and `use_dynamic_year_ranges` are mutually
+exclusive; if both are set `use_git_year_list` takes precedence.
+
 #### comments
 
 The comments section is a list of comment configuration

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -113,6 +113,10 @@ fn default_dynamic_year_ranges() -> bool {
     false
 }
 
+fn default_git_year_list() -> bool {
+    false
+}
+
 #[derive(Deserialize, Debug)]
 pub struct Config {
     files: FileMatcher,
@@ -124,6 +128,8 @@ pub struct Config {
     start_year: Option<String>,
     #[serde(default = "default_dynamic_year_ranges")]
     use_dynamic_year_ranges: bool,
+    #[serde(default = "default_git_year_list")]
+    use_git_year_list: bool,
 
     template: Option<String>,
     auto_template: Option<bool>,
@@ -159,7 +165,20 @@ impl Config {
             }
         };
 
-        let (end_year, start_year) = if self.use_dynamic_year_ranges {
+        let (end_year, start_year) = if self.use_git_year_list {
+            let mut all_years: Vec<String> = get_git_years_for_file(filename)
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>()
+                .into_iter()
+                .collect();
+            all_years.sort();
+
+            let year_list = self
+                .end_year
+                .clone()
+                .unwrap_or_else(|| all_years.join(", "));
+            (Some(year_list), None)
+        } else if self.use_dynamic_year_ranges {
             let git_log_dates = get_git_years_for_file(filename);
             let git_end_year = git_log_dates.first();
             let git_start_year = git_log_dates.last();

--- a/src/template.rs
+++ b/src/template.rs
@@ -109,8 +109,8 @@ pub struct Template {
 // in the license text.
 const INTERMEDIATE_YEAR_TOKEN: &str = "@YR@";
 
-// Matches any full 4-digit year
-const YEAR_RE: &str = "[0-9]{4}(, [0-9]{4})?";
+// Matches any full 4-digit year, or a comma-separated list of years
+const YEAR_RE: &str = "[0-9]{4}(, [0-9]{4})*";
 
 impl Template {
     pub fn new(template: &str, context: Context) -> Template {


### PR DESCRIPTION
This adds an additional option `use_git_year_list` to support listing the modified years in the copyright header. i.e. `Copyright 2019, 2021, 2024`. This was a requirement for my company's usage.

